### PR TITLE
Revert "feat(helm): update helm release ingress-nginx to v4.8.0"

### DIFF
--- a/k8s/deploy/ingress-nginx/Chart.yaml
+++ b/k8s/deploy/ingress-nginx/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.0.1
 
 dependencies:
   - name: ingress-nginx
-    version: 4.8.0
+    version: 4.7.2
     repository: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
Causes issues with ArgoCD and Unifi Ingress - annotations appear to be ignored in this version?